### PR TITLE
Update package pointer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/BiAffectBridge/AssessmentModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "8f085a7fe1b53d8feeea54accf1ceb3b43f1ba84",
-          "version": "1.2.0"
+          "revision": "0d9f9dc99d16372b1936f30ce0fe2d831efd067d",
+          "version": "1.2.1"
         }
       },
       {
@@ -21,11 +21,11 @@
       },
       {
         "package": "MobilePassiveData",
-        "repositoryURL": "https://github.com/BiAffectBridge/MobilePassiveData-SDK.git",
+        "repositoryURL": "https://github.com/BiAffectBridge/MobilePassiveData-Swift.git",
         "state": {
           "branch": null,
-          "revision": "a766738b422ae2f0a894b63bf823f252b3c1545e",
-          "version": "1.6.0"
+          "revision": "b0c9b79f17b198a0398b7bda3bdf80045a9cd422",
+          "version": "1.7.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,9 @@ let package = Package(
                  from: "2.5.0"),
         .package(name: "AssessmentModel",
                  url: "https://github.com/BiAffectBridge/AssessmentModel-Swift.git",
-                 from: "1.2.0"),
+                 from: "1.2.1"),
         .package(name: "MobilePassiveData",
-                 url: "https://github.com/BiAffectBridge/MobilePassiveData-SDK.git",
+                 url: "https://github.com/BiAffectBridge/MobilePassiveData-Swift.git",
                  from: "1.6.0"),
     ],
     targets: [


### PR DESCRIPTION
In order to keep a copy of the Android code that is split from the iOS, the repos in BiAffectBridge are renamed `-Swift` and `-Kotlin` or `KMM` depending upon whether or not they are cross-platform. This updates the name to `-Swift`.